### PR TITLE
Pin bundler version installed in postinstall to 2.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0 / 2023-01-25
+
+* Pin bundler version installed in postinstall to 2.3.26
+
 ## 0.7.6 / 2015-09-28
 
 * Additional windows fixes for recent Omnibus Chef

--- a/busser-rspec.gemspec
+++ b/busser-rspec.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'busser/rspec/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'busser-rspec'
+  spec.name          = 'busser-rspec-datadog'
   spec.version       = Busser::Rspec::VERSION
   spec.authors       = ['Adam Jacob']
   spec.email         = ['adam@opscode.com']

--- a/lib/busser/rspec/version.rb
+++ b/lib/busser/rspec/version.rb
@@ -21,6 +21,6 @@ module Busser
   module Rspec
 
     # Version string for the Rspec Busser runner plugin
-    VERSION = "0.7.6"
+    VERSION = "0.8.0"
   end
 end

--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -26,7 +26,7 @@ require 'rubygems'
 class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
   postinstall do
     install_gem("rspec")
-    install_gem("bundler")
+    install_gem("bundler", "2.3.26")
   end
 
   def test


### PR DESCRIPTION
## What does this PR do?

Pins the `bundler` version to `2.3.26` in the postinstall steps of the gem, to ensure Ruby 2.5 is still supported.

Bumps gem version to 0.8.0.

Renames the built gem to `busser-rspec-datadog`, to not conflict with the upstream gem in Rubygems.