### PR TITLE
Bundle Install error are now print into stdout

### DIFF
--- a/lib/busser/runner_plugin/rspec_datadog.rb
+++ b/lib/busser/runner_plugin/rspec_datadog.rb
@@ -45,7 +45,7 @@ class Busser::RunnerPlugin::RspecDatadog < Busser::RunnerPlugin::Base
         banner('Bundle Installing..')
         ENV['PATH'] = [ENV['PATH'], Gem.bindir, RbConfig::CONFIG['bindir']].join(File::PATH_SEPARATOR)
         bundle_exec = "#{File.join(RbConfig::CONFIG['bindir'], 'ruby')} " +
-          "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path} --no-bundler-warning"
+          "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path} 2>&1"
         run("#{bundle_exec} --local || #{bundle_exec}")
       end
 

--- a/lib/busser/runner_plugin/rspec_datadog.rb
+++ b/lib/busser/runner_plugin/rspec_datadog.rb
@@ -45,7 +45,7 @@ class Busser::RunnerPlugin::RspecDatadog < Busser::RunnerPlugin::Base
         banner('Bundle Installing..')
         ENV['PATH'] = [ENV['PATH'], Gem.bindir, RbConfig::CONFIG['bindir']].join(File::PATH_SEPARATOR)
         bundle_exec = "#{File.join(RbConfig::CONFIG['bindir'], 'ruby')} " +
-          "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path}"
+          "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path} --no-bundler-warning"
         run("#{bundle_exec} --local || #{bundle_exec}")
       end
 


### PR DESCRIPTION
Kitchen tests on windows are considering stderr output as an exit code different from 0.
We're not exactly sure why but ``winrm`` from ``test-kitchen`` receive an exit code 1 when the last command executed has something in stderr.
That's the reason why we need to suppress stderr output on ``bundle install`` and redirect it to stdout since.
Previously our windows kitchen tests didn't have any Gemfile to install in each tests after busser got installed, but since we added the ``rspec_junit_formatter`` dependency to install it is causing some warning on stderr.