### PR TITLE
Bump busser to 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6 / 2023-26-06
+
+* Redirect ``bundle install`` stderr to stdout to fix [some](https://github.com/DataDog/busser-rspec-datadog/pull/5) windows kitchen issues.
+
 ## 0.8.5 / 2023-01-25
 
 * Fix all paths, class names, following gem rename

--- a/lib/busser/rspec_datadog/version.rb
+++ b/lib/busser/rspec_datadog/version.rb
@@ -21,6 +21,6 @@ module Busser
   module RspecDatadog
 
     # Version string for the Rspec Busser runner plugin
-    VERSION = "0.8.5"
+    VERSION = "0.8.6"
   end
 end


### PR DESCRIPTION
# What does this PR do ?
Bump busser to ``0.8.6`` to release last changes from https://github.com/DataDog/busser-rspec-datadog/pull/5